### PR TITLE
Unistaker pending withdrawals

### DIFF
--- a/src/UVN/L1/StakingMiddleware/UniStakerWrapper.sol
+++ b/src/UVN/L1/StakingMiddleware/UniStakerWrapper.sol
@@ -56,7 +56,7 @@ contract UniStakerWrapper is StakeManager, IUniStakerWrapper {
     function depositIntoUniStaker(address governanceDelegatee) external returns (uint256 depositId) {
         if (_isDepositedIntoUniStaker(msg.sender)) revert AlreadyDepositedIntoUniStaker();
         _beforeUniStakerDeposit(msg.sender);
-        uint96 amount = _delegatorStake(msg.sender);
+        uint96 amount = _slashableStake(msg.sender);
         if (amount == 0) revert NoStakeToDeposit();
         depositId = _depositIntoUniStaker(amount, governanceDelegatee);
     }
@@ -65,7 +65,7 @@ contract UniStakerWrapper is StakeManager, IUniStakerWrapper {
     function withdrawFromUniStaker() external {
         if (!_isDepositedIntoUniStaker(msg.sender)) revert NotDepositedIntoUniStaker();
         _beforeUniStakerWithdrawal(msg.sender);
-        uint96 amount = _delegatorStake(msg.sender);
+        uint96 amount = _slashableStake(msg.sender);
         _withdrawFromUniStaker(amount);
     }
 

--- a/test/UVN/L1/StakingMiddleware/ProtocolRewardDistributor.t.sol
+++ b/test/UVN/L1/StakingMiddleware/ProtocolRewardDistributor.t.sol
@@ -476,6 +476,7 @@ contract ProtocolRewardDistributorTest is L1TestHandler {
                         vm.startPrank(depositor);
                         protocolRewardDistributor.withdrawFromUniStaker();
                         protocolRewardDistributor.unstake(amounts[j]);
+                        protocolRewardDistributor.withdraw(depositor, 1);
                         totalAmount -= amounts[j];
                         amounts[j] = 0;
                         vm.stopPrank();

--- a/test/UVN/L1/StakingMiddleware/UniStakerWrapper.t.sol
+++ b/test/UVN/L1/StakingMiddleware/UniStakerWrapper.t.sol
@@ -222,4 +222,12 @@ contract UniStakerWrapperTest is L1TestHandler {
         assertTotalAmountStaked(remainingStake);
         assertEq(stakeToken.balanceOf(slashingBeneficiary), stakeAmount - remainingStake);
     }
+
+    function test_shouldDepositPendingWithdrawals() public {
+        unistakerWrapper.stake(10);
+        unistakerWrapper.unstake(9);
+        unistakerWrapper.depositIntoUniStaker(delegatee);
+        assertTotalAmountStaked(10);
+        unistakerWrapper.withdraw(address(this), 1);
+    }
 }


### PR DESCRIPTION
This pull request updates the `UniStakerWrapper` contract to use a more accurate calculation for the stake amount by replacing `_delegatorStake` with `_slashableStake`. Additionally, it introduces a new test to validate the behavior of depositing pending withdrawals.

### Changes to stake calculation:

* [`src/UVN/L1/StakingMiddleware/UniStakerWrapper.sol`](diffhunk://#diff-b85b56737865c83150701accdd6c4f238dbc58dfa0ca362e991f0279e428c58bL59-R59): Updated both the `depositIntoUniStaker` and `withdrawFromUniStaker` functions to use `_slashableStake` instead of `_delegatorStake` for determining the stake amount. This ensures that the stake amount considers only the slashable portion. [[1]](diffhunk://#diff-b85b56737865c83150701accdd6c4f238dbc58dfa0ca362e991f0279e428c58bL59-R59) [[2]](diffhunk://#diff-b85b56737865c83150701accdd6c4f238dbc58dfa0ca362e991f0279e428c58bL68-R68)

### New test case:

* [`test/UVN/L1/StakingMiddleware/UniStakerWrapper.t.sol`](diffhunk://#diff-4cfcbc9aa5189d5581a712fe7dafe7f9c6c4ac4b3a48785f8ae7dbbcefbb1e77R225-R232): Added a new test, `test_shouldDepositPendingWithdrawals`, to verify that pending withdrawals are correctly deposited into the UniStaker and that the total staked amount is updated as expected.