### PR TITLE
Fix slashable stake on withdrawal

### DIFF
--- a/src/UVN/L1/StakingMiddleware/OperatorManager.sol
+++ b/src/UVN/L1/StakingMiddleware/OperatorManager.sol
@@ -44,7 +44,10 @@ abstract contract OperatorManager is OperatorVotes, ProtocolRewardDistributor, I
     /// @dev After a delegator withdraws their unstaked stake, decrease the slashable stake of the operator
     function _afterWithdraw(address delegator, uint96 amount) internal virtual override {
         super._afterWithdraw(delegator, amount);
-        _slashableStakes[delegates(delegator)] -= amount;
+        address operator = delegates(delegator);
+        if (operator != address(0)) {
+            _slashableStakes[operator] -= amount;
+        }
     }
 
     /// @inheritdoc IOperatorManager

--- a/test/UVN/L1/StakingMiddleware/OperatorManager.t.sol
+++ b/test/UVN/L1/StakingMiddleware/OperatorManager.t.sol
@@ -6,7 +6,7 @@ import {UniStakerWrapper} from '../../../../src/UVN/L1/StakingMiddleware/UniStak
 import {IUniStaker} from '../../../../src/interfaces/UVN/L1/IUnistaker.sol';
 import {IDelegatorAccessControl} from '../../../../src/interfaces/UVN/L1/StakingMiddleware/IDelegatorAccessControl.sol';
 import {IDelegatorVerifier} from '../../../../src/interfaces/UVN/L1/StakingMiddleware/IDelegatorVerifier.sol';
-
+import {IStakeManager} from '../../../../src/interfaces/UVN/L1/StakingMiddleware/IStakeManager.sol';
 import {L1TestHandler} from '../L1TestHandler.sol';
 import {IVotes} from '@openzeppelin/contracts/governance/utils/IVotes.sol';
 import {ECDSA} from '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
@@ -334,5 +334,13 @@ contract OperatorManagerTest is L1TestHandler {
         assertTotalVotes(
             DEFAULT_AMOUNT + remainingVotes, 'total votes should decrease by slashed amount of the slashed operator'
         );
+    }
+
+    function test_shouldNotDecreaseSlashableStakeOnWithdrawalIfUndelegated() public {
+        operatorManager.stake(DEFAULT_AMOUNT);
+        operatorManager.unstake(DEFAULT_AMOUNT);
+        vm.expectEmit();
+        emit IStakeManager.Withdrawn(address(this), address(this), DEFAULT_AMOUNT);
+        operatorManager.withdraw(address(this), 1);
     }
 }


### PR DESCRIPTION
This pull request introduces a bug fix and a new test case in the `OperatorManager` contract and its associated test suite. The changes ensure that the slashable stake is only decreased when a valid operator is associated with a delegator and add a test to verify this behavior.

### Bug Fix in `OperatorManager` Contract:
* Updated the `_afterWithdraw` function in `OperatorManager` to check if the operator address is non-zero before decreasing the slashable stake. This prevents unintended behavior when a delegator has undelegated. (`src/UVN/L1/StakingMiddleware/OperatorManager.sol`, [src/UVN/L1/StakingMiddleware/OperatorManager.solL47-R50](diffhunk://#diff-f32d832f1bc25e0ea86273e08187abb588a3a2bc0649c92bc1601e8d1fadd2fdL47-R50))

### Test Suite Enhancements:
* Added a new test case, `test_shouldNotDecreaseSlashableStakeOnWithdrawalIfUndelegated`, to verify that the slashable stake is not decreased when a delegator has undelegated before withdrawal. (`test/UVN/L1/StakingMiddleware/OperatorManager.t.sol`, [test/UVN/L1/StakingMiddleware/OperatorManager.t.solR338-R345](diffhunk://#diff-0d69360cd2e245911b8cdf8b0e1d2af2ab5f59d85cbd7397a3c9be4ad352c7ceR338-R345))
* Imported the `IStakeManager` interface in the test file to support the new test case. (`test/UVN/L1/StakingMiddleware/OperatorManager.t.sol`, [test/UVN/L1/StakingMiddleware/OperatorManager.t.solL9-R9](diffhunk://#diff-0d69360cd2e245911b8cdf8b0e1d2af2ab5f59d85cbd7397a3c9be4ad352c7ceL9-R9))