### PR TITLE
Fix order of operations when unstaking

### DIFF
--- a/src/UVN/L1/StakingMiddleware/StakeManager.sol
+++ b/src/UVN/L1/StakingMiddleware/StakeManager.sol
@@ -43,10 +43,10 @@ contract StakeManager is StakingMiddlewareParams, IStakeManager {
 
     /// @inheritdoc IStakeManager
     function unstake(uint96 amount) external returns (uint256 withdrawalId) {
+        _beforeUnstake(msg.sender, amount);
         Stake storage stake_ = _depositorStake[msg.sender];
         uint256 currentStake = stake_.stake;
         if (currentStake < amount) revert InsufficientBalance();
-        _beforeUnstake(msg.sender, amount);
         stake_.stake -= amount;
         withdrawalId = _schedulePendingWithdrawal(msg.sender, amount);
         emit Unstaked(msg.sender, amount);

--- a/test/UVN/L1/StakingMiddleware/StakeManager.t.sol
+++ b/test/UVN/L1/StakingMiddleware/StakeManager.t.sol
@@ -28,15 +28,15 @@ contract StakeManagerTestHarness is StakeManager {
         _slashDelegatorStake(delegator, remainingPercentage);
     }
 
-    /// Implement _before* hooks to track changes to the ghost stake
+    /// Implement _after* hooks to track changes to the ghost stake
 
-    function _beforeStake(address delegator, uint96 amount) internal override {
-        super._beforeStake(delegator, amount);
+    function _afterStake(address delegator, uint96 amount) internal override {
+        super._afterStake(delegator, amount);
         _ghostDepositorStake[delegator].stake += amount;
     }
 
-    function _beforeUnstake(address delegator, uint96 amount) internal override {
-        super._beforeUnstake(delegator, amount);
+    function _afterUnstake(address delegator, uint96 amount) internal override {
+        super._afterUnstake(delegator, amount);
         _ghostDepositorStake[delegator].stake -= amount;
         // Add pending withdraw to ghost stake
         _ghostSchedulePendingWithdrawal(delegator, amount);


### PR DESCRIPTION
This pull request refactors the staking middleware in the `StakeManager` contract and its test harness to replace `_before*` hooks with `_after*` hooks, ensuring proper tracking of changes to the ghost stake. Additionally, it fixes the order of the `_beforeUnstake` call in the `unstake` function.

### Refactoring to `_after*` hooks:

* [`test/UVN/L1/StakingMiddleware/StakeManager.t.sol`](diffhunk://#diff-a9c50e020133a2272d1bc40e7dd19e62017cbb941e02ecbfab51afc8ff330d4bL31-R39): Replaced `_beforeStake` and `_beforeUnstake` hooks with `_afterStake` and `_afterUnstake` hooks to track changes to the ghost stake after the corresponding actions are performed. This ensures updates to `_ghostDepositorStake` and `_ghostSchedulePendingWithdrawal` occur after the main logic.

### Bug fix in `_beforeUnstake` call order:

* [`src/UVN/L1/StakingMiddleware/StakeManager.sol`](diffhunk://#diff-c24c3b49ee54e6aaff56e0a22d373a349f1ad0cd09498589e66250ab17df4f86R46-L49): Moved the `_beforeUnstake` call in the `unstake` function to occur before checking and modifying the stake balance. This ensures preconditions are validated before making changes.