### PR TITLE
Fix order of calculations on slashing on withdrawals

### DIFF
--- a/docs/autogen/src/src/UVN/L1/StakingMiddleware/SlashingManager.sol/abstract.SlashingManager.md
+++ b/docs/autogen/src/src/UVN/L1/StakingMiddleware/SlashingManager.sol/abstract.SlashingManager.md
@@ -1,5 +1,5 @@
 # SlashingManager
-[Git Source](https://github.com/Uniswap/unichain-contracts/blob/d36fee7571a3aee70804ae50127a8ca3e2e6fc63/src/UVN/L1/StakingMiddleware/SlashingManager.sol)
+[Git Source](https://github.com/Uniswap/unichain-contracts/blob/88a508cf5f865f18b7ea2dc21cac2d745a2aa0c7/src/UVN/L1/StakingMiddleware/SlashingManager.sol)
 
 **Inherits:**
 [DelegatorAccessControl](/src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol/abstract.DelegatorAccessControl.md), [ISlashingManager](/src/interfaces/UVN/L1/StakingMiddleware/ISlashingManager.sol/interface.ISlashingManager.md)
@@ -241,15 +241,6 @@ function _calculateSlashing(address delegator, uint256 n, uint256 globalCheckpoi
 function _isDelegatorSlashed(uint256 nextDelegatorInstance, uint256 operatorLength) internal pure returns (bool);
 ```
 
-### _slashingOccurred
-
-*Checks a slashing result whether a slashing occurred, if the remaining percentage is not 100%, a slashing occurred*
-
-
-```solidity
-function _slashingOccurred(SlashingResult memory result, address delegator) internal view returns (bool);
-```
-
 ### _afterSlash
 
 
@@ -282,6 +273,7 @@ struct SlashingInstance {
 
 ```solidity
 struct SlashingResult {
+    bool slashed;
     uint256 remainingStake;
     uint256 remainingWithdrawals;
     uint256 next;

--- a/docs/autogen/src/src/UVN/L1/StakingMiddleware/SlashingManager.sol/abstract.SlashingManager.md
+++ b/docs/autogen/src/src/UVN/L1/StakingMiddleware/SlashingManager.sol/abstract.SlashingManager.md
@@ -1,5 +1,5 @@
 # SlashingManager
-[Git Source](https://github.com/Uniswap/unichain-contracts/blob/31f7d1e84e305ebb14dd3f50a3450497938c6404/src/UVN/L1/StakingMiddleware/SlashingManager.sol)
+[Git Source](https://github.com/Uniswap/unichain-contracts/blob/7f66025a53e574ca519390c88a9335515138fc79/src/UVN/L1/StakingMiddleware/SlashingManager.sol)
 
 **Inherits:**
 [DelegatorAccessControl](/src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol/abstract.DelegatorAccessControl.md), [ISlashingManager](/src/interfaces/UVN/L1/StakingMiddleware/ISlashingManager.sol/interface.ISlashingManager.md)
@@ -70,13 +70,13 @@ function _beforeStake(address delegator, uint96 amount) internal override;
 function _beforeUnstake(address delegator, uint96 amount) internal override;
 ```
 
-### _beforeWithdraw
+### _beforeWithdrawCalculation
 
 *Before a delegator withdraws, apply all pending slashing instances to the delegator's stake*
 
 
 ```solidity
-function _beforeWithdraw(address delegator, uint96 amount) internal override;
+function _beforeWithdrawCalculation(address delegator) internal override;
 ```
 
 ### _beforeUniStakerDeposit

--- a/docs/autogen/src/src/UVN/L1/StakingMiddleware/SlashingManager.sol/abstract.SlashingManager.md
+++ b/docs/autogen/src/src/UVN/L1/StakingMiddleware/SlashingManager.sol/abstract.SlashingManager.md
@@ -1,5 +1,5 @@
 # SlashingManager
-[Git Source](https://github.com/Uniswap/unichain-contracts/blob/7f66025a53e574ca519390c88a9335515138fc79/src/UVN/L1/StakingMiddleware/SlashingManager.sol)
+[Git Source](https://github.com/Uniswap/unichain-contracts/blob/d36fee7571a3aee70804ae50127a8ca3e2e6fc63/src/UVN/L1/StakingMiddleware/SlashingManager.sol)
 
 **Inherits:**
 [DelegatorAccessControl](/src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol/abstract.DelegatorAccessControl.md), [ISlashingManager](/src/interfaces/UVN/L1/StakingMiddleware/ISlashingManager.sol/interface.ISlashingManager.md)
@@ -207,6 +207,17 @@ function delegatorStake(address delegator) public view override(StakeManager, IS
 function slashableStake(address delegator) public view override(StakeManager, IStakeManager) returns (uint96);
 ```
 
+### pendingWithdrawalAmount
+
+
+```solidity
+function pendingWithdrawalAmount(address delegator)
+    public
+    view
+    override(StakeManager, IStakeManager)
+    returns (uint96);
+```
+
 ### _calculateSlashing
 
 *iterates over slashing occurrences by the operator a delegator has selected. For every slashing instance, it calculates the new stake based on the total percentage of the total delegated stake slashed.*
@@ -230,22 +241,13 @@ function _calculateSlashing(address delegator, uint256 n, uint256 globalCheckpoi
 function _isDelegatorSlashed(uint256 nextDelegatorInstance, uint256 operatorLength) internal pure returns (bool);
 ```
 
-### _remainingStake
-
-*Applies a slashing result to a stake*
-
-
-```solidity
-function _remainingStake(uint96 stake_, SlashingResult memory result) internal pure returns (uint96);
-```
-
 ### _slashingOccurred
 
 *Checks a slashing result whether a slashing occurred, if the remaining percentage is not 100%, a slashing occurred*
 
 
 ```solidity
-function _slashingOccurred(SlashingResult memory result) internal pure returns (bool);
+function _slashingOccurred(SlashingResult memory result, address delegator) internal view returns (bool);
 ```
 
 ### _afterSlash
@@ -280,7 +282,8 @@ struct SlashingInstance {
 
 ```solidity
 struct SlashingResult {
-    uint256 remainingPercentage;
+    uint256 remainingStake;
+    uint256 remainingWithdrawals;
     uint256 next;
     uint256 newRewards;
     uint256 slashedRewards;

--- a/docs/autogen/src/src/UVN/L1/StakingMiddleware/StakeManager.sol/contract.StakeManager.md
+++ b/docs/autogen/src/src/UVN/L1/StakingMiddleware/StakeManager.sol/contract.StakeManager.md
@@ -1,5 +1,5 @@
 # StakeManager
-[Git Source](https://github.com/Uniswap/unichain-contracts/blob/c6fb0d16c45440c99bf5e7d1fa8e991b11a08777/src/UVN/L1/StakingMiddleware/StakeManager.sol)
+[Git Source](https://github.com/Uniswap/unichain-contracts/blob/7f66025a53e574ca519390c88a9335515138fc79/src/UVN/L1/StakingMiddleware/StakeManager.sol)
 
 **Inherits:**
 [StakingMiddlewareParams](/src/UVN/L1/StakingMiddleware/StakingMiddlewareParams.sol/contract.StakingMiddlewareParams.md), [IStakeManager](/src/interfaces/UVN/L1/StakingMiddleware/IStakeManager.sol/interface.IStakeManager.md)
@@ -199,6 +199,13 @@ function _beforeUnstake(address delegator, uint96 amount) internal virtual;
 
 ```solidity
 function _afterUnstake(address delegator, uint96 amount) internal virtual;
+```
+
+### _beforeWithdrawCalculation
+
+
+```solidity
+function _beforeWithdrawCalculation(address delegator) internal virtual;
 ```
 
 ### _beforeWithdraw

--- a/docs/autogen/src/src/UVN/L1/StakingMiddleware/StakeManager.sol/contract.StakeManager.md
+++ b/docs/autogen/src/src/UVN/L1/StakingMiddleware/StakeManager.sol/contract.StakeManager.md
@@ -1,5 +1,5 @@
 # StakeManager
-[Git Source](https://github.com/Uniswap/unichain-contracts/blob/7f66025a53e574ca519390c88a9335515138fc79/src/UVN/L1/StakingMiddleware/StakeManager.sol)
+[Git Source](https://github.com/Uniswap/unichain-contracts/blob/d36fee7571a3aee70804ae50127a8ca3e2e6fc63/src/UVN/L1/StakingMiddleware/StakeManager.sol)
 
 **Inherits:**
 [StakingMiddlewareParams](/src/UVN/L1/StakingMiddleware/StakingMiddlewareParams.sol/contract.StakingMiddlewareParams.md), [IStakeManager](/src/interfaces/UVN/L1/StakingMiddleware/IStakeManager.sol/interface.IStakeManager.md)
@@ -117,7 +117,7 @@ Returns the amount of pending withdrawals for a delegator
 
 
 ```solidity
-function pendingWithdrawalAmount(address delegator) external view returns (uint96);
+function pendingWithdrawalAmount(address delegator) public view virtual returns (uint96);
 ```
 
 ### withdrawal
@@ -140,7 +140,7 @@ function withdrawal(address delegator, uint256 withdrawalId)
 
 
 ```solidity
-function _slashDelegatorStake(address delegator, uint256 remainingPercentage) internal;
+function _slashDelegatorStake(address delegator, uint96 newStake, uint96 newPendingWithdrawalAmount) internal;
 ```
 
 ### _schedulePendingWithdrawal

--- a/src/UVN/L1/StakingMiddleware/SlashingManager.sol
+++ b/src/UVN/L1/StakingMiddleware/SlashingManager.sol
@@ -63,9 +63,9 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
     }
 
     /// @dev Before a delegator withdraws, apply all pending slashing instances to the delegator's stake
-    function _beforeWithdraw(address delegator, uint96 amount) internal override {
+    function _beforeWithdrawCalculation(address delegator) internal override {
         applySlashing(delegator, type(uint256).max);
-        super._beforeWithdraw(delegator, amount);
+        super._beforeWithdrawCalculation(delegator);
     }
 
     /// @dev Before a delegator deposits into the UniStaker contract, apply all pending slashing instances to the delegator's stake

--- a/src/UVN/L1/StakingMiddleware/SlashingManager.sol
+++ b/src/UVN/L1/StakingMiddleware/SlashingManager.sol
@@ -21,8 +21,10 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
 
     /// @dev Result of a slashing calculation
     struct SlashingResult {
-        /// @dev The remaining percentage of the slashable stake of a delegator after applying slashing instances
-        uint256 remainingPercentage;
+        /// @dev The remaining stake of a delegator after applying slashing instances
+        uint256 remainingStake;
+        /// @dev The remaining pending withdrawals of a delegator after applying slashing instances
+        uint256 remainingWithdrawals;
         /// @dev The next slashing instance of a delegator, if all slashing instances have been applied, the next slashing instance will be the operator's slashing instances array length, else the delegator is still slashable
         uint256 next;
         /// @dev The new rewards of a delegator after applying slashing instances, adjusted by the slashed stake
@@ -127,7 +129,7 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
         uint256 globalRewardCheckpoint = _updateGlobalRewardCheckpoint();
 
         SlashingResult memory result = _calculateSlashing(delegator, n, globalRewardCheckpoint);
-        if (!_slashingOccurred(result)) return;
+        if (!_slashingOccurred(result, delegator)) return;
 
         // update the next slashing instance
         _delegatorNextSlashingInstance[delegator] = result.next;
@@ -137,7 +139,7 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
         if (result.slashedRewards != 0) {
             REWARD_TOKEN.transfer(slashingBeneficiary(), result.slashedRewards);
         }
-        _slashDelegatorStake(delegator, result.remainingPercentage);
+        _slashDelegatorStake(delegator, uint96(result.remainingStake), uint96(result.remainingWithdrawals));
         _afterDelegatorSlash(delegator);
     }
 
@@ -160,7 +162,7 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
         uint256 unclaimedGlobalReward = UNISTAKER.unclaimedReward(address(this));
         uint256 globalCheckpoint = _getNewGlobalRewardCheckpoint(unclaimedGlobalReward);
         SlashingResult memory result = _calculateSlashing(delegator, type(uint256).max, globalCheckpoint);
-        if (_slashingOccurred(result)) {
+        if (_slashingOccurred(result, delegator)) {
             return _earnedRewardsOf[delegator] + result.newRewards;
         }
         return super.rewardsOf(delegator);
@@ -182,13 +184,23 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
     /// @dev Overrides the `delegatorStake` function in `StakeManager` to reflect correct stake for a delegator accounting for slashing
     function delegatorStake(address delegator) public view override(StakeManager, IStakeManager) returns (uint96) {
         SlashingResult memory result = _calculateSlashing(delegator, type(uint256).max, _globalRewardCheckpoint);
-        return _remainingStake(_delegatorStake(delegator), result);
+        return uint96(result.remainingStake);
     }
 
     /// @dev Overrides the `slashableStake` function in `StakeManager` to reflect correct slashable stake for a delegator accounting for slashing
     function slashableStake(address delegator) public view override(StakeManager, IStakeManager) returns (uint96) {
         SlashingResult memory result = _calculateSlashing(delegator, type(uint256).max, _globalRewardCheckpoint);
-        return _remainingStake(_slashableStake(delegator), result);
+        return uint96(result.remainingStake + result.remainingWithdrawals);
+    }
+
+    function pendingWithdrawalAmount(address delegator)
+        public
+        view
+        override(StakeManager, IStakeManager)
+        returns (uint96)
+    {
+        SlashingResult memory result = _calculateSlashing(delegator, type(uint256).max, _globalRewardCheckpoint);
+        return uint96(result.remainingWithdrawals);
     }
 
     /// @dev iterates over slashing occurrences by the operator a delegator has selected. For every slashing instance, it calculates the new stake based on the total percentage of the total delegated stake slashed.
@@ -199,9 +211,9 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
         returns (SlashingResult memory result)
     {
         address operator = _slashableOperatorOf(delegator);
-        uint96 currentStake = _delegatorStake(delegator);
         result.newCheckpoint = _rewardCheckpointOf[delegator];
-        result.remainingPercentage = PERCENTAGE_DENOMINATOR;
+        result.remainingStake = _delegatorStake(delegator);
+        result.remainingWithdrawals = StakeManager.pendingWithdrawalAmount(delegator);
         result.next = _delegatorNextSlashingInstance[delegator];
         uint256 operatorLength = _slashingInstances[operator].length;
         if (operator == address(0) || !_isDelegatorSlashed(result.next, operatorLength)) {
@@ -218,7 +230,7 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
             }
             SlashingInstance memory instance = _slashingInstances[operator][result.next];
             // current stake before the slashing instance occurred, if i == 0, it's the unslashed stake, else it's the remaining stake after the previous slashing instance occurred
-            uint256 stakeBefore = _remainingStake(currentStake, result);
+            uint256 stakeBefore = result.remainingStake + result.remainingWithdrawals;
             if (isDeposited) {
                 // calculate rewards earned before the slashing instance occurred (e.g., before the delegator was slashed until the slashing instance occurred if i == 0 or from the last slashing instance until the current slashing instance if i > 0)
                 result.newRewards +=
@@ -227,21 +239,24 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
                 result.newCheckpoint = instance.rewardCheckpoint;
             }
             // apply the remaining percentage of the slashing instance to the remaining stake of the delegator
-            result.remainingPercentage =
-                (result.remainingPercentage * instance.remainingPercentage) / PERCENTAGE_DENOMINATOR;
+            result.remainingStake =
+                uint96((result.remainingStake * instance.remainingPercentage) / PERCENTAGE_DENOMINATOR);
+            result.remainingWithdrawals =
+                uint96((result.remainingWithdrawals * instance.remainingPercentage) / PERCENTAGE_DENOMINATOR);
             // mark the slashing instance as applied by incrementing to the next slashing instance
             result.next++;
             i++;
             if (isDeposited) {
                 // calculate the rewards the slashed stake accrued from the moment of the slashing until now
-                uint256 slashedStake = stakeBefore - _remainingStake(currentStake, result);
+                uint256 slashedStake = stakeBefore - result.remainingStake - result.remainingWithdrawals;
                 result.slashedRewards += _calculateRewardFromTo(slashedStake, result.newCheckpoint, globalCheckpoint);
             }
         }
         if (isDeposited) {
             // after all slashing instances have been applied, calculate the new rewards for the remaining stake from the last slashing instance until now
-            result.newRewards +=
-                _calculateRewardFromTo(_remainingStake(currentStake, result), result.newCheckpoint, globalCheckpoint);
+            result.newRewards += _calculateRewardFromTo(
+                result.remainingStake + result.remainingWithdrawals, result.newCheckpoint, globalCheckpoint
+            );
             result.newCheckpoint = globalCheckpoint;
         }
     }
@@ -251,14 +266,9 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
         return nextDelegatorInstance < operatorLength;
     }
 
-    /// @dev Applies a slashing result to a stake
-    function _remainingStake(uint96 stake_, SlashingResult memory result) internal pure returns (uint96) {
-        return uint96((uint256(stake_) * result.remainingPercentage) / PERCENTAGE_DENOMINATOR);
-    }
-
     /// @dev Checks a slashing result whether a slashing occurred, if the remaining percentage is not 100%, a slashing occurred
-    function _slashingOccurred(SlashingResult memory result) internal pure returns (bool) {
-        return result.remainingPercentage != PERCENTAGE_DENOMINATOR;
+    function _slashingOccurred(SlashingResult memory result, address delegator) internal view returns (bool) {
+        return result.remainingStake != _delegatorStake(delegator);
     }
 
     function _afterSlash(address operator, uint256 remainingPercentage) internal virtual {}

--- a/src/UVN/L1/StakingMiddleware/SlashingManager.sol
+++ b/src/UVN/L1/StakingMiddleware/SlashingManager.sol
@@ -21,6 +21,8 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
 
     /// @dev Result of a slashing calculation
     struct SlashingResult {
+        /// @dev Whether a slashing occurred
+        bool slashed;
         /// @dev The remaining stake of a delegator after applying slashing instances
         uint256 remainingStake;
         /// @dev The remaining pending withdrawals of a delegator after applying slashing instances
@@ -129,7 +131,7 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
         uint256 globalRewardCheckpoint = _updateGlobalRewardCheckpoint();
 
         SlashingResult memory result = _calculateSlashing(delegator, n, globalRewardCheckpoint);
-        if (!_slashingOccurred(result, delegator)) return;
+        if (!result.slashed) return;
 
         // update the next slashing instance
         _delegatorNextSlashingInstance[delegator] = result.next;
@@ -162,7 +164,7 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
         uint256 unclaimedGlobalReward = UNISTAKER.unclaimedReward(address(this));
         uint256 globalCheckpoint = _getNewGlobalRewardCheckpoint(unclaimedGlobalReward);
         SlashingResult memory result = _calculateSlashing(delegator, type(uint256).max, globalCheckpoint);
-        if (_slashingOccurred(result, delegator)) {
+        if (result.slashed) {
             return _earnedRewardsOf[delegator] + result.newRewards;
         }
         return super.rewardsOf(delegator);
@@ -220,6 +222,7 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
             // user not delegated to an operator or not slashed
             return result;
         }
+        result.slashed = true;
         // if the delegator has deposited their stake into the UniStaker contract, slash their rewards
         bool isDeposited = _isDepositedIntoUniStaker(delegator);
         uint256 i = 0;
@@ -264,11 +267,6 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
     /// @dev Checks whether a delegator has pending slashing instances, if the next slashing instance is equal to the operator's slashing instances array length, the delegator is not slashed
     function _isDelegatorSlashed(uint256 nextDelegatorInstance, uint256 operatorLength) internal pure returns (bool) {
         return nextDelegatorInstance < operatorLength;
-    }
-
-    /// @dev Checks a slashing result whether a slashing occurred, if the remaining percentage is not 100%, a slashing occurred
-    function _slashingOccurred(SlashingResult memory result, address delegator) internal view returns (bool) {
-        return result.remainingStake != _delegatorStake(delegator);
     }
 
     function _afterSlash(address operator, uint256 remainingPercentage) internal virtual {}

--- a/src/UVN/L1/StakingMiddleware/StakeManager.sol
+++ b/src/UVN/L1/StakingMiddleware/StakeManager.sol
@@ -93,7 +93,7 @@ contract StakeManager is StakingMiddlewareParams, IStakeManager {
     }
 
     /// @inheritdoc IStakeManager
-    function pendingWithdrawalAmount(address delegator) external view returns (uint96) {
+    function pendingWithdrawalAmount(address delegator) public view virtual returns (uint96) {
         return _depositorStake[delegator].totalPendingWithdrawal;
     }
 
@@ -109,20 +109,17 @@ contract StakeManager is StakingMiddlewareParams, IStakeManager {
     /// @dev To ensure accurate accounting of total delegated stake to operators, pending withdrawals and slashable stake are slashed equally
     /// @dev When pending withdrawals are slashed, cancel all pending withdrawals and create a new one with the remainder
     // @audit INVARIANT: The remaining slashed stake is always less or equal to the stake before the slashing minus the amount slashed to ensure the contract always has enough stake to cover the withdrawal of the entire stake
-    function _slashDelegatorStake(address delegator, uint256 remainingPercentage) internal {
+    function _slashDelegatorStake(address delegator, uint96 newStake, uint96 newPendingWithdrawalAmount) internal {
         Stake storage stake_ = _depositorStake[delegator];
-        uint256 currentStake = stake_.stake;
-        uint256 currentPendingWithdrawalAmount = stake_.totalPendingWithdrawal;
-        uint96 newStake = uint96(currentStake * remainingPercentage / PERCENTAGE_DENOMINATOR);
-        uint96 newPendingWithdrawalAmount =
-            uint96(currentPendingWithdrawalAmount * remainingPercentage / PERCENTAGE_DENOMINATOR);
+        uint96 currentStake = stake_.stake;
+        uint96 currentPendingWithdrawalAmount = stake_.totalPendingWithdrawal;
         if (currentPendingWithdrawalAmount != 0) {
             // cancel all pending withdrawals and schedule a new one with the remainder
             _invalidatePendingWithdrawals(delegator);
             _schedulePendingWithdrawal(delegator, newPendingWithdrawalAmount);
         }
         if (currentStake != 0) {
-            _depositorStake[delegator].stake = uint96(newStake);
+            _depositorStake[delegator].stake = newStake;
         }
         uint96 slashedAmount =
             uint96(currentStake + currentPendingWithdrawalAmount - newStake - newPendingWithdrawalAmount);

--- a/src/UVN/L1/StakingMiddleware/StakeManager.sol
+++ b/src/UVN/L1/StakingMiddleware/StakeManager.sol
@@ -55,6 +55,7 @@ contract StakeManager is StakingMiddlewareParams, IStakeManager {
 
     /// @inheritdoc IStakeManager
     function withdraw(address to, uint64 n) external returns (uint96 amount) {
+        _beforeWithdrawCalculation(msg.sender);
         Stake storage stake_ = _depositorStake[msg.sender];
         uint256 len = stake_.pendingWithdrawals.length;
         uint64 head = stake_.head;
@@ -173,6 +174,8 @@ contract StakeManager is StakingMiddlewareParams, IStakeManager {
     function _beforeUnstake(address delegator, uint96 amount) internal virtual {}
 
     function _afterUnstake(address delegator, uint96 amount) internal virtual {}
+
+    function _beforeWithdrawCalculation(address delegator) internal virtual {}
 
     function _beforeWithdraw(address delegator, uint96 amount) internal virtual {}
 

--- a/test/UVN/L1/StakingMiddleware/SlashingManager.t.sol
+++ b/test/UVN/L1/StakingMiddleware/SlashingManager.t.sol
@@ -309,4 +309,15 @@ contract StakingMiddlewareSlashingTest is L1TestHandler {
         uint256 actualReward = slashingManager.withdrawRewards(delegator);
         assertEq(actualReward, totalReward, 'actual reward does not match shown rewards');
     }
+
+    function test_delegatorBalanceShouldBeConsistentWithOperatorBalance() public {
+        depositAndDelegate(delegator, 9);
+        vm.prank(slasher);
+        slashingManager.slashAmount(operator, 1);
+        vm.prank(slasher);
+        slashingManager.slashAmount(operator, 1);
+        vm.prank(delegator);
+        // this should not cause an underflow
+        slashingManager.announceOperatorUndelegation();
+    }
 }

--- a/test/UVN/L1/StakingMiddleware/StakeManager.t.sol
+++ b/test/UVN/L1/StakingMiddleware/StakeManager.t.sol
@@ -24,8 +24,8 @@ contract StakeManagerTestHarness is StakeManager {
     {}
 
     /// @notice Helper function to test the internal _slashDelegatorStake function
-    function slashDelegatorStake(address delegator, uint256 remainingPercentage) external {
-        _slashDelegatorStake(delegator, remainingPercentage);
+    function slashDelegatorStake(address delegator, uint96 newStake, uint96 newPendingWithdrawalAmount) external {
+        _slashDelegatorStake(delegator, newStake, newPendingWithdrawalAmount);
     }
 
     /// Implement _before* hooks to track changes to the ghost stake
@@ -198,14 +198,17 @@ contract StakeManagerInvariantHandler is Test {
     function slash(uint256 remainingPercentage, uint256 actorIndexSeed) external useActor(actorIndexSeed) {
         uint96 _delegatorStake = stakeManagerTestHarness.delegatorStake(currentActor);
         uint96 _slashableStake = stakeManagerTestHarness.slashableStake(currentActor);
-
+        uint96 _pendingWithdrawalAmount = stakeManagerTestHarness.pendingWithdrawalAmount(currentActor);
         remainingPercentage = _boundToUint256(remainingPercentage, 1e18);
 
-        stakeManagerTestHarness.slashDelegatorStake(currentActor, remainingPercentage);
+        uint256 newStake = _delegatorStake * remainingPercentage / 1e18;
+        uint256 newPendingWithdrawalAmount = _pendingWithdrawalAmount * remainingPercentage / 1e18;
+        stakeManagerTestHarness.slashDelegatorStake(currentActor, uint96(newStake), uint96(newPendingWithdrawalAmount));
 
         // Stakes after slashing must be less than or equal to the original stake
         assertLe(stakeManagerTestHarness.delegatorStake(currentActor), _delegatorStake);
         assertLe(stakeManagerTestHarness.slashableStake(currentActor), _slashableStake);
+        assertLe(stakeManagerTestHarness.pendingWithdrawalAmount(currentActor), _pendingWithdrawalAmount);
     }
 }
 
@@ -405,18 +408,20 @@ contract StakeManagerTest is L1TestHandler {
 
     function test_slashDelegatorStake() public {
         uint96 amount = 1000;
-
+        uint96 unstakeAmount = 400;
         // Setup
         stakeToken.mint(delegator, amount);
         vm.startPrank(delegator);
         stakeToken.approve(address(stakeManager), amount);
         stakeManager.stake(amount);
-        stakeManager.unstake(400);
+        stakeManager.unstake(unstakeAmount);
         vm.stopPrank();
 
         // Use the exposed slashDelegatorStake function (80% remaining)
         uint256 remainingPercentage = 0.8e18; // 80% in fixed point
-        stakeManager.slashDelegatorStake(delegator, remainingPercentage);
+        uint96 newStake = uint96((amount - unstakeAmount) * remainingPercentage / 1e18);
+        uint96 newPendingWithdrawalAmount = uint96(unstakeAmount * remainingPercentage / 1e18);
+        stakeManager.slashDelegatorStake(delegator, newStake, newPendingWithdrawalAmount);
 
         // Verify - after slashing 20%, we should have 80% of the original stake left
         assertEq(stakeManager.delegatorStake(delegator), 480); // 600 * 0.8 = 480
@@ -429,22 +434,25 @@ contract StakeManagerTest is L1TestHandler {
 
     function test_slashDelegatorStake_multiplePendingWithdrawals() public {
         uint96 amount = 1000;
-
+        uint96 unstakeAmount1 = 200;
+        uint96 unstakeAmount2 = 300;
         // Setup
         stakeToken.mint(delegator, amount);
         vm.startPrank(delegator);
         stakeToken.approve(address(stakeManager), amount);
         stakeManager.stake(amount);
         // Create two pending withdrawals
-        stakeManager.unstake(200);
-        stakeManager.unstake(300);
+        stakeManager.unstake(unstakeAmount1);
+        stakeManager.unstake(unstakeAmount2);
         vm.stopPrank();
 
         // Use the exposed slashDelegatorStake function (70% remaining)
         uint256 remainingPercentage = 0.7e18; // 70% in fixed point
+        uint96 newStake = uint96((amount - unstakeAmount1 - unstakeAmount2) * remainingPercentage / 1e18);
+        uint96 newPendingWithdrawalAmount = uint96((unstakeAmount1 + unstakeAmount2) * remainingPercentage / 1e18);
         vm.expectEmit();
         emit IStakeManager.PendingWithdrawalsInvalidated(delegator, 0, 1);
-        stakeManager.slashDelegatorStake(delegator, remainingPercentage);
+        stakeManager.slashDelegatorStake(delegator, newStake, newPendingWithdrawalAmount);
 
         // Verify - after slashing 30%, we should have 70% of the original stake left
         assertEq(stakeManager.delegatorStake(delegator), 350); // 500 * 0.7 = 350

--- a/test/UVN/L1/StakingMiddleware/UniStakerWrapper.t.sol
+++ b/test/UVN/L1/StakingMiddleware/UniStakerWrapper.t.sol
@@ -12,8 +12,8 @@ contract UniStakerWrapperHarness is UniStakerWrapper {
         UniStakerWrapper(unistaker, initialAdmin, withdrawalDelay_, slashingBeneficiary_)
     {}
 
-    function slashDelegatorStake(address delegator, uint256 remainingPercentage) external {
-        _slashDelegatorStake(delegator, remainingPercentage);
+    function slashDelegatorStake(address delegator, uint96 newStake, uint96 newPendingWithdrawalAmount) external {
+        _slashDelegatorStake(delegator, newStake, newPendingWithdrawalAmount);
     }
 }
 
@@ -215,9 +215,9 @@ contract UniStakerWrapperTest is L1TestHandler {
     function test_shouldWithdrawSlashedAmountBeforeSlashing() public {
         uint96 stakeAmount = 1000;
         uint256 remainingPercentage = 0.4e18;
-        deposit(address(this), stakeAmount);
-        unistakerWrapper.slashDelegatorStake(address(this), remainingPercentage);
         uint256 remainingStake = stakeAmount * remainingPercentage / 1e18;
+        deposit(address(this), stakeAmount);
+        unistakerWrapper.slashDelegatorStake(address(this), uint96(remainingStake), 0);
         assertBalance(address(this), remainingStake);
         assertTotalAmountStaked(remainingStake);
         assertEq(stakeToken.balanceOf(slashingBeneficiary), stakeAmount - remainingStake);


### PR DESCRIPTION
This pull request includes updates to the `SlashingManager` and `StakeManager` contracts and their documentation. The changes primarily focus on renaming and refactoring the `_beforeWithdraw` function to `_beforeWithdrawCalculation` for clarity and consistency, as well as updating references and adding new internal function definitions.

### Changes to `SlashingManager`:

* Renamed the `_beforeWithdraw` function to `_beforeWithdrawCalculation` in the `SlashingManager` contract to improve clarity. Updated the function's logic to call `applySlashing` and the corresponding `super` method with the new function name.

### Changes to `StakeManager`:

* Added a new internal function `_beforeWithdrawCalculation` to the `StakeManager` contract and invoked it within the `withdraw` method to handle pre-withdrawal logic. [[1]](diffhunk://#diff-c24c3b49ee54e6aaff56e0a22d373a349f1ad0cd09498589e66250ab17df4f86R58) [[2]](diffhunk://#diff-c24c3b49ee54e6aaff56e0a22d373a349f1ad0cd09498589e66250ab17df4f86R178-R179)

### Documentation updates:

* Updated the Git source links in the autogenerated documentation for both `SlashingManager` and `StakeManager` to reflect the latest commit hash. [[1]](diffhunk://#diff-794281f5a9f971d9cb15e92c4455daac5cf3ce51f53d3476ae60791615fe0d45L2-R2) [[2]](diffhunk://#diff-d0bb55bd07f0cf8718aadbc6207c41c34d2bdf534286004be24775171c6a8241L2-R2)
* Renamed the `_beforeWithdraw` section to `_beforeWithdrawCalculation` in the autogenerated documentation for `SlashingManager` and added a new section for `_beforeWithdrawCalculation` in the `StakeManager` documentation. [[1]](diffhunk://#diff-794281f5a9f971d9cb15e92c4455daac5cf3ce51f53d3476ae60791615fe0d45L73-R79) [[2]](diffhunk://#diff-d0bb55bd07f0cf8718aadbc6207c41c34d2bdf534286004be24775171c6a8241R204-R210)