### PR TITLE
Ensure undelegation announcement before undelegation

### DIFF
--- a/docs/autogen/src/src/interfaces/UVN/L1/StakingMiddleware/IOperatorManager.sol/interface.IOperatorManager.md
+++ b/docs/autogen/src/src/interfaces/UVN/L1/StakingMiddleware/IOperatorManager.sol/interface.IOperatorManager.md
@@ -1,5 +1,5 @@
 # IOperatorManager
-[Git Source](https://github.com/Uniswap/unichain-contracts/blob/c6fb0d16c45440c99bf5e7d1fa8e991b11a08777/src/interfaces/UVN/L1/StakingMiddleware/IOperatorManager.sol)
+[Git Source](https://github.com/Uniswap/unichain-contracts/blob/f3a7525f5971b3bc886ba551e43cf8afecfdaa02/src/interfaces/UVN/L1/StakingMiddleware/IOperatorManager.sol)
 
 **Inherits:**
 [IProtocolRewardDistributor](/src/interfaces/UVN/L1/StakingMiddleware/IProtocolRewardDistributor.sol/interface.IProtocolRewardDistributor.md), IVotes
@@ -48,20 +48,28 @@ event OperatorUndelegationAnnounced(address indexed delegator, address indexed o
 ```
 
 ## Errors
-### OperatorAlreadySelected
-Thrown when a delegator attempts to delegate to another operator while already delegating to one
+### AlreadyDelegated
+Thrown when a delegator attempts to delegate to another operator while already delegating to one or having a pending undelegation
 
 
 ```solidity
-error OperatorAlreadySelected();
+error AlreadyDelegated();
 ```
 
-### NoOperatorSelected
+### NotDelegated
 Thrown when a delegator attempts to undelegate from an operator while not delegating to one
 
 
 ```solidity
-error NoOperatorSelected();
+error NotDelegated();
+```
+
+### AnnounceUndelegationFirst
+Thrown when a delegator attempts to undelegate from an operator without announcing their intention to undelegate first
+
+
+```solidity
+error AnnounceUndelegationFirst();
 ```
 
 ### UndelegationNotFinalized

--- a/src/UVN/L1/StakingMiddleware/OperatorManager.sol
+++ b/src/UVN/L1/StakingMiddleware/OperatorManager.sol
@@ -57,7 +57,7 @@ abstract contract OperatorManager is OperatorVotes, ProtocolRewardDistributor, I
         if (_undelegationData[delegator].operator != address(0)) {
             revert UndelegationNotFinalized(_undelegationData[delegator].undelegateAt);
         }
-        if (operator == address(0)) revert NoOperatorSelected();
+        if (operator == address(0)) revert NotDelegated();
         _beforeUndelegationAnnouncement(delegator);
         uint96 undelegateAt = uint96(block.timestamp + withdrawalDelay());
         _undelegationData[delegator] = UndelegationData({operator: operator, undelegateAt: undelegateAt});
@@ -84,9 +84,9 @@ abstract contract OperatorManager is OperatorVotes, ProtocolRewardDistributor, I
 
     /// @dev Delegates a delegator's stake to an operator, the delegator must not be already delegating to an operator and must have any pending undelegation finalized
     function _selectOperator(address delegator, address operator) internal {
-        if (delegates(delegator) != address(0)) revert OperatorAlreadySelected();
-        uint256 undelegateAt = _undelegationData[delegator].undelegateAt;
-        if (undelegateAt > block.timestamp) {
+        if (delegates(delegator) != address(0)) revert AlreadyDelegated();
+        if (_undelegationData[delegator].operator != address(0)) {
+            uint256 undelegateAt = _undelegationData[delegator].undelegateAt;
             revert UndelegationNotFinalized(undelegateAt);
         }
         _beforeDelegation(delegator, operator);
@@ -96,9 +96,11 @@ abstract contract OperatorManager is OperatorVotes, ProtocolRewardDistributor, I
     /// @dev Undelegates a delegator from an operator, the delegator must first announce their intention to undelegate by calling `announceOperatorUndelegation`. This function can only be called once the delay has passed.
     function _deselectOperator(address delegator) internal {
         address operator = delegates(delegator);
+        // delegator is already delegating to an operator
+        if (operator != address(0)) revert AnnounceUndelegationFirst();
         UndelegationData memory undelegationData = _undelegationData[delegator];
         // delegator is not delegating and has no pending undelegation
-        if (undelegationData.operator == address(0) && operator == address(0)) revert NoOperatorSelected();
+        if (undelegationData.operator == address(0)) revert NotDelegated();
         if (undelegationData.undelegateAt > block.timestamp) {
             revert UndelegationNotFinalized(undelegationData.undelegateAt);
         }

--- a/src/interfaces/UVN/L1/StakingMiddleware/IOperatorManager.sol
+++ b/src/interfaces/UVN/L1/StakingMiddleware/IOperatorManager.sol
@@ -13,11 +13,14 @@ interface IOperatorManager is IProtocolRewardDistributor, IVotes {
     /// @notice Emitted when a delegator announces their intention to undelegate from their current operator
     event OperatorUndelegationAnnounced(address indexed delegator, address indexed operator, uint256 timestamp);
 
-    /// @notice Thrown when a delegator attempts to delegate to another operator while already delegating to one
-    error OperatorAlreadySelected();
+    /// @notice Thrown when a delegator attempts to delegate to another operator while already delegating to one or having a pending undelegation
+    error AlreadyDelegated();
 
     /// @notice Thrown when a delegator attempts to undelegate from an operator while not delegating to one
-    error NoOperatorSelected();
+    error NotDelegated();
+
+    /// @notice Thrown when a delegator attempts to undelegate from an operator without announcing their intention to undelegate first
+    error AnnounceUndelegationFirst();
 
     /// @notice Thrown when a delegator attempts to undelegate from an operator while the undelegation is not finalized
     error UndelegationNotFinalized(uint256 timestamp);

--- a/test/UVN/L1/StakingMiddleware/DelegatorAccessControl.t.sol
+++ b/test/UVN/L1/StakingMiddleware/DelegatorAccessControl.t.sol
@@ -526,7 +526,7 @@ contract DelegatorAccessControlTest is L1TestHandler {
 
         // Cannot delegate to operatorB while already delegated
         vm.prank(delegatorA);
-        vm.expectRevert(IOperatorManager.OperatorAlreadySelected.selector);
+        vm.expectRevert(IOperatorManager.AlreadyDelegated.selector);
         delegatorAccessControl.delegate(operatorB);
 
         // Undelegate from operatorA - first announce undelegation
@@ -539,7 +539,12 @@ contract DelegatorAccessControlTest is L1TestHandler {
         // Wait for the delay period
         vm.warp(block.timestamp + 7 days + 1);
 
+        // cannot delegate without undelegation first
+        vm.expectRevert(abi.encodeWithSelector(IOperatorManager.UndelegationNotFinalized.selector, block.timestamp - 1));
+        delegatorAccessControl.delegate(operatorB);
+
         // Now we can delegate to operatorB
+        delegatorAccessControl.delegate(address(0));
         delegatorAccessControl.delegate(operatorB);
         vm.stopPrank();
 

--- a/test/UVN/L1/StakingMiddleware/OperatorManager.t.sol
+++ b/test/UVN/L1/StakingMiddleware/OperatorManager.t.sol
@@ -191,7 +191,7 @@ contract OperatorManagerTest is L1TestHandler {
 
     function test_shouldNotBeAbleToDelegateWhileAlreadyDelegating() public {
         operatorManager.delegate(operator);
-        vm.expectRevert(IOperatorManager.OperatorAlreadySelected.selector);
+        vm.expectRevert(IOperatorManager.AlreadyDelegated.selector);
         operatorManager.delegate(operator);
     }
 
@@ -249,12 +249,12 @@ contract OperatorManagerTest is L1TestHandler {
     }
 
     function test_shouldNotBeAbleToUndelegateWhileNotDelegated() public {
-        vm.expectRevert(abi.encodeWithSelector(IOperatorManager.NoOperatorSelected.selector));
+        vm.expectRevert(abi.encodeWithSelector(IOperatorManager.NotDelegated.selector));
         operatorManager.delegate(address(0));
     }
 
     function test_shouldNotBeAbleToAnnounceUndelegationWhileUndelegated() public {
-        vm.expectRevert(abi.encodeWithSelector(IOperatorManager.NoOperatorSelected.selector));
+        vm.expectRevert(abi.encodeWithSelector(IOperatorManager.NotDelegated.selector));
         operatorManager.announceOperatorUndelegation();
     }
 
@@ -342,5 +342,20 @@ contract OperatorManagerTest is L1TestHandler {
         vm.expectEmit();
         emit IStakeManager.Withdrawn(address(this), address(this), DEFAULT_AMOUNT);
         operatorManager.withdraw(address(this), 1);
+    }
+
+    function test_RevertIf_DelegatingWhileUndelegationIsPending() public {
+        vm.startPrank(delegator);
+        operatorManager.delegate(operator);
+        operatorManager.announceOperatorUndelegation();
+        vm.expectRevert(abi.encodeWithSelector(IOperatorManager.UndelegationNotFinalized.selector, block.timestamp));
+        operatorManager.delegate(delegator);
+        vm.stopPrank();
+    }
+
+    function test_RevertIf_UndelegatingWithoutAnnouncingUndelegation() public {
+        operatorManager.delegate(operator);
+        vm.expectRevert(IOperatorManager.AnnounceUndelegationFirst.selector);
+        operatorManager.delegate(address(0));
     }
 }


### PR DESCRIPTION
This pull request refactors error handling and updates tests in the `OperatorManager` contract to improve clarity and enforce stricter delegation and undelegation rules. The key changes include renaming error codes for better readability, introducing a new error for undelegation without prior announcement, and updating associated tests to reflect these changes.

### Error Handling Updates:

* Renamed `OperatorAlreadySelected` to `AlreadyDelegated` and updated its logic to include cases where a pending undelegation exists. (`src/UVN/L1/StakingMiddleware/OperatorManager.sol`, `src/interfaces/UVN/L1/StakingMiddleware/IOperatorManager.sol`) [[1]](diffhunk://#diff-f32d832f1bc25e0ea86273e08187abb588a3a2bc0649c92bc1601e8d1fadd2fdL87-L89) [[2]](diffhunk://#diff-65aaddae5ce5830363c0635c33158435390414fafd67833192f30b96bad1294cL16-R23)
* Renamed `NoOperatorSelected` to `NotDelegated` for better clarity. (`src/UVN/L1/StakingMiddleware/OperatorManager.sol`, `src/interfaces/UVN/L1/StakingMiddleware/IOperatorManager.sol`) [[1]](diffhunk://#diff-f32d832f1bc25e0ea86273e08187abb588a3a2bc0649c92bc1601e8d1fadd2fdL60-R60) [[2]](diffhunk://#diff-65aaddae5ce5830363c0635c33158435390414fafd67833192f30b96bad1294cL16-R23)
* Introduced a new error, `AnnounceUndelegationFirst`, to enforce the requirement of announcing undelegation before executing it. (`src/UVN/L1/StakingMiddleware/OperatorManager.sol`, `src/interfaces/UVN/L1/StakingMiddleware/IOperatorManager.sol`) [[1]](diffhunk://#diff-f32d832f1bc25e0ea86273e08187abb588a3a2bc0649c92bc1601e8d1fadd2fdR99-R103) [[2]](diffhunk://#diff-65aaddae5ce5830363c0635c33158435390414fafd67833192f30b96bad1294cL16-R23)

### Test Updates:

* Updated test cases to use the new error names (`AlreadyDelegated`, `NotDelegated`) and added checks for the new `AnnounceUndelegationFirst` error. (`test/UVN/L1/StakingMiddleware/DelegatorAccessControl.t.sol`, `test/UVN/L1/StakingMiddleware/OperatorManager.t.sol`) [[1]](diffhunk://#diff-e8ff3b6004e57b65fbf008c2043b9a4d581f37db4ee03eb82eeccbce35b5fdd7L529-R529) [[2]](diffhunk://#diff-0d69360cd2e245911b8cdf8b0e1d2af2ab5f59d85cbd7397a3c9be4ad352c7ceL252-R257)
* Added new test cases to ensure proper error handling when attempting to delegate during pending undelegation or undelegate without prior announcement. (`test/UVN/L1/StakingMiddleware/OperatorManager.t.sol`)

### Documentation Update:

* Updated the `IOperatorManager` interface documentation to reflect the renamed errors and the newly introduced `AnnounceUndelegationFirst` error. (`docs/autogen/src/src/interfaces/UVN/L1/StakingMiddleware/IOperatorManager.sol/interface.IOperatorManager.md`) [[1]](diffhunk://#diff-86f5aa51b539d4be9aaf054e27c5571f35c6c79b2df66a727ddd9be3a7cd36d9L2-R2) [[2]](diffhunk://#diff-86f5aa51b539d4be9aaf054e27c5571f35c6c79b2df66a727ddd9be3a7cd36d9L51-R72)