### PR TITLE
DelegatorAccessControl: Fix parameter name

### DIFF
--- a/docs/autogen/src/src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol/abstract.DelegatorAccessControl.md
+++ b/docs/autogen/src/src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol/abstract.DelegatorAccessControl.md
@@ -1,5 +1,5 @@
 # DelegatorAccessControl
-[Git Source](https://github.com/Uniswap/unichain-contracts/blob/c6fb0d16c45440c99bf5e7d1fa8e991b11a08777/src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol)
+[Git Source](https://github.com/Uniswap/unichain-contracts/blob/3acb5f12419bea9fea7cca34c0464a9cc73593b7/src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol)
 
 **Inherits:**
 [OperatorManager](/src/UVN/L1/StakingMiddleware/OperatorManager.sol/abstract.OperatorManager.md), [IDelegatorAccessControl](/src/interfaces/UVN/L1/StakingMiddleware/IDelegatorAccessControl.sol/interface.IDelegatorAccessControl.md)
@@ -11,7 +11,7 @@ This contract manages the access control of delegators to operators. It allows O
 ### _delegatorAccessControl
 
 ```solidity
-mapping(address delegator => AccessControlParams accessControl) private _delegatorAccessControl;
+mapping(address operator => AccessControlParams accessControl) private _delegatorAccessControl;
 ```
 
 

--- a/src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol
+++ b/src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol
@@ -16,7 +16,7 @@ abstract contract DelegatorAccessControl is OperatorManager, IDelegatorAccessCon
         IDelegatorVerifier verifier;
     }
 
-    mapping(address delegator => AccessControlParams accessControl) private _delegatorAccessControl;
+    mapping(address operator => AccessControlParams accessControl) private _delegatorAccessControl;
 
     /// @dev Before a delegator selects an operator, check if they are allowed to delegate to them
     function _beforeDelegation(address delegator, address operator) internal override {


### PR DESCRIPTION
This pull request updates the `DelegatorAccessControl` contract and its associated documentation to fix an issue with the mapping key and ensure consistency between the code and documentation. The most important changes include correcting the mapping key in the contract and updating the corresponding documentation to reflect this change.

### Changes to `DelegatorAccessControl` contract:

* Updated the `_delegatorAccessControl` mapping key from `address delegator` to `address operator` to correctly associate access control parameters with operators instead of delegators. (`src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol`, [src/UVN/L1/StakingMiddleware/DelegatorAccessControl.solL19-R19](diffhunk://#diff-f5c49b72e940ed6c28ab6898d5e3bf7fe215a89062f19b14c620af4f8f2558c7L19-R19))

### Documentation updates:

* Updated the `_delegatorAccessControl` mapping definition in the autogenerated documentation to match the corrected mapping key in the contract. (`docs/autogen/src/src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol/abstract.DelegatorAccessControl.md`, [docs/autogen/src/src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol/abstract.DelegatorAccessControl.mdL14-R14](diffhunk://#diff-c85e929bb058647b49dcb12169a6f8a6165f2e148f88377d97ba360dd50fdd0cL14-R14))
* Updated the Git source link in the autogenerated documentation to point to the latest commit reflecting the changes in the contract. (`docs/autogen/src/src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol/abstract.DelegatorAccessControl.md`, [docs/autogen/src/src/UVN/L1/StakingMiddleware/DelegatorAccessControl.sol/abstract.DelegatorAccessControl.mdL2-R2](diffhunk://#diff-c85e929bb058647b49dcb12169a6f8a6165f2e148f88377d97ba360dd50fdd0cL2-R2))