### PR TITLE
always update the global reward checkpoint

### DIFF
--- a/src/UVN/L1/StakingMiddleware/SlashingManager.sol
+++ b/src/UVN/L1/StakingMiddleware/SlashingManager.sol
@@ -135,9 +135,7 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
 
         // update the next slashing instance
         _delegatorNextSlashingInstance[delegator] = result.next;
-        if (result.newRewards != 0) {
-            _distributeRewards(delegator, result.newRewards, result.newCheckpoint);
-        }
+        _distributeRewards(delegator, result.newRewards, result.newCheckpoint);
         if (result.slashedRewards != 0) {
             REWARD_TOKEN.transfer(slashingBeneficiary(), result.slashedRewards);
         }


### PR DESCRIPTION
This pull request includes a small change in the `SlashingManager` contract to simplify the logic for distributing rewards. The conditional check for `result.newRewards` before calling `_distributeRewards` was removed, ensuring the method is called unconditionally. 

This change affects the following file:

* [`src/UVN/L1/StakingMiddleware/SlashingManager.sol`](diffhunk://#diff-c0f889eeea52571934caddff6141a020c6c0d02d419c95382bd315559c823ad5L138-L140): Removed the conditional around `_distributeRewards`, simplifying the reward distribution logic.