### PR TITLE
Use explicit calls

### DIFF
--- a/src/UVN/L1/StakingMiddleware.sol
+++ b/src/UVN/L1/StakingMiddleware.sol
@@ -19,6 +19,6 @@ contract StakingMiddleware is Notifier, Multicall, IStakingMiddleware {
     /// @inheritdoc Nonces
     /// @dev The `Nonces` library does not come with an interface, to ensure that the function is included in the interface of this contract, add it here
     function nonces(address owner) public view override(Nonces, IStakingMiddleware) returns (uint256) {
-        return super.nonces(owner);
+        return Nonces.nonces(owner);
     }
 }

--- a/src/UVN/L1/StakingMiddleware/Notifier.sol
+++ b/src/UVN/L1/StakingMiddleware/Notifier.sol
@@ -175,7 +175,7 @@ abstract contract Notifier is SlashingManager, ERC721, INotifier {
     /// @dev Allow the operator to always force transfer their own token
     function _isAuthorized(address owner, address spender, uint256 tokenId) internal view override returns (bool) {
         if (spender == OperatorTokenLib.toAddress(tokenId)) return true;
-        return super._isAuthorized(owner, spender, tokenId);
+        return ERC721._isAuthorized(owner, spender, tokenId);
     }
 
     /// @dev Checks if an account is a service contract by ensuring that the account is not an EOA or 7702 enabled account and that the smart contract supports the `IService` interface

--- a/src/UVN/L1/StakingMiddleware/OperatorManager.sol
+++ b/src/UVN/L1/StakingMiddleware/OperatorManager.sol
@@ -61,7 +61,7 @@ abstract contract OperatorManager is OperatorVotes, ProtocolRewardDistributor, I
         _beforeUndelegationAnnouncement(delegator);
         uint96 undelegateAt = uint96(block.timestamp + withdrawalDelay());
         _undelegationData[delegator] = UndelegationData({operator: operator, undelegateAt: undelegateAt});
-        super._delegate(delegator, address(0));
+        OperatorVotes._delegate(delegator, address(0));
         emit OperatorUndelegationAnnounced(delegator, operator, undelegateAt);
         _afterUndelegationAnnouncement(delegator);
     }
@@ -77,7 +77,7 @@ abstract contract OperatorManager is OperatorVotes, ProtocolRewardDistributor, I
             _deselectOperator(delegator);
         } else {
             _selectOperator(delegator, operator);
-            super._delegate(delegator, operator);
+            OperatorVotes._delegate(delegator, operator);
             _afterDelegation(delegator, operator);
         }
     }

--- a/src/UVN/L1/StakingMiddleware/SlashingManager.sol
+++ b/src/UVN/L1/StakingMiddleware/SlashingManager.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.26;
 
 import {ISlashingManager} from '../../../interfaces/UVN/L1/StakingMiddleware/ISlashingManager.sol';
 import {DelegatorAccessControl} from './DelegatorAccessControl.sol';
+import {OperatorManager} from './OperatorManager.sol';
 import {IProtocolRewardDistributor, ProtocolRewardDistributor} from './ProtocolRewardDistributor.sol';
 import {IStakeManager, StakeManager} from './StakeManager.sol';
 
@@ -167,7 +168,7 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
         if (result.slashed) {
             return _earnedRewardsOf[delegator] + result.newRewards;
         }
-        return super.rewardsOf(delegator);
+        return ProtocolRewardDistributor.rewardsOf(delegator);
     }
 
     // @audit Can introduce minor rounding errors between the sum of all remaining balances and the the recorded total stake due to rounding errors
@@ -179,7 +180,7 @@ abstract contract SlashingManager is DelegatorAccessControl, ISlashingManager {
             rewardCheckpoint: globalRewardCheckpoint
         });
         _slashingInstances[operator].push(instance);
-        super._slashOperatorVotes(operator, remainingPercentage);
+        OperatorManager._slashOperatorVotes(operator, remainingPercentage);
         _afterSlash(operator, remainingPercentage);
     }
 

--- a/test/UVN/L1/StakingMiddleware.t.sol
+++ b/test/UVN/L1/StakingMiddleware.t.sol
@@ -3,6 +3,11 @@ pragma solidity 0.8.26;
 
 import {L1TestHandler} from './L1TestHandler.sol';
 
+import {IAccessControl} from '@openzeppelin/contracts/access/IAccessControl.sol';
+import {IERC721} from '@openzeppelin/contracts/token/ERC721/IERC721.sol';
+import {IERC721Metadata} from '@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol';
+import {IERC165} from '@openzeppelin/contracts/utils/introspection/IERC165.sol';
+
 contract StakingMiddlewareTest is L1TestHandler {
     function setUp() public override {
         super.setUp();
@@ -19,5 +24,13 @@ contract StakingMiddlewareTest is L1TestHandler {
         stakingMiddleware.delegate(operator);
         assertEq(stakingMiddleware.delegatorStake(address(this)), 1000);
         assertEq(stakingMiddleware.getVotes(operator), 1000);
+    }
+
+    function test_supportingInterfaces() public view {
+        IERC165 erc165 = IERC165(address(stakingMiddleware));
+        assertEq(erc165.supportsInterface(type(IERC165).interfaceId), true);
+        assertEq(erc165.supportsInterface(type(IERC721).interfaceId), true);
+        assertEq(erc165.supportsInterface(type(IERC721Metadata).interfaceId), true);
+        assertEq(erc165.supportsInterface(type(IAccessControl).interfaceId), true);
     }
 }


### PR DESCRIPTION
This pull request refactors several components of the `StakingMiddleware` system to improve modularity and maintainability by replacing `super` calls with explicit base contract references. Additionally, it introduces new imports and tests to enhance functionality and ensure interface compliance.

### Refactoring for explicit base contract usage:
* [`src/UVN/L1/StakingMiddleware.sol`](diffhunk://#diff-7d5d7479ff6099c383a33af0e48686a7477d510ddd4291d283ce6f977f604cf6L22-R22): Updated the `nonces` function to directly call `Nonces.nonces(owner)` instead of `super.nonces(owner)` for clarity and explicitness.
* [`src/UVN/L1/StakingMiddleware/Notifier.sol`](diffhunk://#diff-6cd3396887ff343a2b52509d95231aa8b9e4431b1aaea0e2dc482dac6f68f9f5L178-R178): Modified `_isAuthorized` to call `ERC721._isAuthorized` instead of `super._isAuthorized`.
* [`src/UVN/L1/StakingMiddleware/OperatorManager.sol`](diffhunk://#diff-f32d832f1bc25e0ea86273e08187abb588a3a2bc0649c92bc1601e8d1fadd2fdL64-R64): Updated `_delegate` calls to use `OperatorVotes._delegate` instead of `super._delegate`. [[1]](diffhunk://#diff-f32d832f1bc25e0ea86273e08187abb588a3a2bc0649c92bc1601e8d1fadd2fdL64-R64) [[2]](diffhunk://#diff-f32d832f1bc25e0ea86273e08187abb588a3a2bc0649c92bc1601e8d1fadd2fdL80-R80)
* [`src/UVN/L1/StakingMiddleware/SlashingManager.sol`](diffhunk://#diff-c0f889eeea52571934caddff6141a020c6c0d02d419c95382bd315559c823ad5L170-R171): Replaced `super` calls with explicit references to `ProtocolRewardDistributor.rewardsOf` and `OperatorManager._slashOperatorVotes`. [[1]](diffhunk://#diff-c0f889eeea52571934caddff6141a020c6c0d02d419c95382bd315559c823ad5L170-R171) [[2]](diffhunk://#diff-c0f889eeea52571934caddff6141a020c6c0d02d419c95382bd315559c823ad5L182-R183)

### Import enhancements:
* [`src/UVN/L1/StakingMiddleware/SlashingManager.sol`](diffhunk://#diff-c0f889eeea52571934caddff6141a020c6c0d02d419c95382bd315559c823ad5R6): Added an import for `OperatorManager` to support explicit references in slashing-related logic.
* [`test/UVN/L1/StakingMiddleware.t.sol`](diffhunk://#diff-442348138beabe35af098c4193d6431f904342076e92bcc265c082101dc372ebR6-R10): Added imports for OpenZeppelin interfaces (`IAccessControl`, `IERC721`, `IERC721Metadata`, `IERC165`) to facilitate testing of interface compliance.

### New tests for interface compliance:
* [`test/UVN/L1/StakingMiddleware.t.sol`](diffhunk://#diff-442348138beabe35af098c4193d6431f904342076e92bcc265c082101dc372ebR28-R35): Introduced a `test_supportingInterfaces` function to verify that `StakingMiddleware` supports the `IERC165`, `IERC721`, `IERC721Metadata`, and `IAccessControl` interfaces.