### PR TITLE
remove todo

### DIFF
--- a/src/UVN/L1/StakingMiddleware/UniStakerWrapper.sol
+++ b/src/UVN/L1/StakingMiddleware/UniStakerWrapper.sol
@@ -113,7 +113,6 @@ contract UniStakerWrapper is StakeManager, IUniStakerWrapper {
     /// @dev Withdraws an amount from a delegator's stake deposited into the UniStaker contract. If the entire stake is withdrawn, subsequent deposits will no longer auto-deposit into the UniStaker contract.
     function _withdrawFromUniStaker(address delegator, uint96 amount) internal {
         uint256 depositId = _depositIds[delegator];
-        // TODO revert if not deposited and amount is not 0
         if (depositId != 0) {
             UNISTAKER.withdraw(IUniStaker.DepositIdentifier.wrap(depositId), amount);
             emit UniStakerWithdrawn(delegator, depositId, amount);


### PR DESCRIPTION
This pull request includes a minor change to the `UniStakerWrapper` contract. The change removes a TODO comment in the `_withdrawFromUniStaker` function, indicating that the functionality to revert if not deposited and the amount is not zero has either been implemented elsewhere or deemed unnecessary.