### PR TITLE
Use calldata instead of memory

### DIFF
--- a/docs/autogen/src/src/UVN/L1/StakingMiddleware/Notifier.sol/abstract.Notifier.md
+++ b/docs/autogen/src/src/UVN/L1/StakingMiddleware/Notifier.sol/abstract.Notifier.md
@@ -1,5 +1,5 @@
 # Notifier
-[Git Source](https://github.com/Uniswap/unichain-contracts/blob/31f7d1e84e305ebb14dd3f50a3450497938c6404/src/UVN/L1/StakingMiddleware/Notifier.sol)
+[Git Source](https://github.com/Uniswap/unichain-contracts/blob/3acb5f12419bea9fea7cca34c0464a9cc73593b7/src/UVN/L1/StakingMiddleware/Notifier.sol)
 
 **Inherits:**
 [SlashingManager](/src/UVN/L1/StakingMiddleware/SlashingManager.sol/abstract.SlashingManager.md), ERC721, [INotifier](/src/interfaces/UVN/L1/StakingMiddleware/INotifier.sol/interface.INotifier.md)
@@ -131,7 +131,7 @@ Allows an operator to set the URI for their token
 
 
 ```solidity
-function setURI(string memory uri) external;
+function setURI(string calldata uri) external;
 ```
 
 ### tokenURI

--- a/docs/autogen/src/src/UVN/L2/RewardDistributor.sol/contract.RewardDistributor.md
+++ b/docs/autogen/src/src/UVN/L2/RewardDistributor.sol/contract.RewardDistributor.md
@@ -1,5 +1,5 @@
 # RewardDistributor
-[Git Source](https://github.com/Uniswap/unichain-contracts/blob/c6fb0d16c45440c99bf5e7d1fa8e991b11a08777/src/UVN/L2/RewardDistributor.sol)
+[Git Source](https://github.com/Uniswap/unichain-contracts/blob/3acb5f12419bea9fea7cca34c0464a9cc73593b7/src/UVN/L2/RewardDistributor.sol)
 
 **Inherits:**
 [RewardDistributorParams](/src/UVN/L2/RewardDistributorParams.sol/contract.RewardDistributorParams.md), [IRewardDistributor](/src/interfaces/UVN/L2/IRewardDistributor.sol/interface.IRewardDistributor.md)
@@ -81,8 +81,8 @@ Attest to a window of blocks
 function attest(
     uint256 blockNumber,
     bytes32 blockHash,
-    bytes memory additionalData,
-    bytes memory signature,
+    bytes calldata additionalData,
+    bytes calldata signature,
     bytes32 graffiti
 ) external;
 ```

--- a/snapshots/RewardDistributorTest.json
+++ b/snapshots/RewardDistributorTest.json
@@ -1,6 +1,6 @@
 {
-  "delayedAttestation": "333794",
-  "finalizingAttestation": "175876",
-  "rawAttestation": "140804",
-  "schedulingAttestation": "331380"
+  "delayedAttestation": "333712",
+  "finalizingAttestation": "175794",
+  "rawAttestation": "140723",
+  "schedulingAttestation": "331298"
 }

--- a/src/UVN/L1/StakingMiddleware/Notifier.sol
+++ b/src/UVN/L1/StakingMiddleware/Notifier.sol
@@ -91,7 +91,7 @@ abstract contract Notifier is SlashingManager, ERC721, INotifier {
     }
 
     /// @inheritdoc INotifier
-    function setURI(string memory uri) external {
+    function setURI(string calldata uri) external {
         uint256 tokenId = OperatorTokenLib.toTokenId(msg.sender);
         _requireOwned(tokenId);
         _uris[msg.sender] = uri;

--- a/src/UVN/L2/RewardDistributor.sol
+++ b/src/UVN/L2/RewardDistributor.sol
@@ -55,8 +55,8 @@ contract RewardDistributor is RewardDistributorParams, IRewardDistributor {
     function attest(
         uint256 blockNumber,
         bytes32 blockHash,
-        bytes memory additionalData,
-        bytes memory signature,
+        bytes calldata additionalData,
+        bytes calldata signature,
         bytes32 graffiti
     ) external {
         if (blockNumber >= block.number) revert NoBlockHashAvailable();


### PR DESCRIPTION
This pull request includes updates to improve gas efficiency by replacing `memory` with `calldata` for function parameters, updates to documentation links for consistency with the latest commit, and changes to test snapshots to reflect updated contract behavior.

### Code Efficiency Improvements:
* Updated the `setURI` function in `Notifier.sol` to use `calldata` instead of `memory` for its `uri` parameter, reducing gas costs. (`src/UVN/L1/StakingMiddleware/Notifier.sol`, [src/UVN/L1/StakingMiddleware/Notifier.solL94-R94](diffhunk://#diff-6cd3396887ff343a2b52509d95231aa8b9e4431b1aaea0e2dc482dac6f68f9f5L94-R94))
* Updated the `attest` function in `RewardDistributor.sol` to use `calldata` instead of `memory` for `additionalData` and `signature` parameters, improving gas efficiency. (`src/UVN/L2/RewardDistributor.sol`, [src/UVN/L2/RewardDistributor.solL58-R59](diffhunk://#diff-a579c06acd0f4e4fdc985116f7f6d4eca3c92d07d6cb390b76f7ba2896fe762eL58-R59))

### Documentation Updates:
* Updated the Git source links in `Notifier.md` and `RewardDistributor.md` to reference the latest commit hash for consistency. [[1]](diffhunk://#diff-63e75ac769d03f77edcd53a9c5c7d4d20c70b3bd4c0a8fb59a2a8abc43b68a26L2-R2) [[2]](diffhunk://#diff-7479b846a183902a8feac3e00011bc9eea4d9cd1336a903dffed11a351e6fdaaL2-R2)
* Updated Solidity code snippets in `Notifier.md` and `RewardDistributor.md` to reflect the changes from `memory` to `calldata`. [[1]](diffhunk://#diff-63e75ac769d03f77edcd53a9c5c7d4d20c70b3bd4c0a8fb59a2a8abc43b68a26L134-R134) [[2]](diffhunk://#diff-7479b846a183902a8feac3e00011bc9eea4d9cd1336a903dffed11a351e6fdaaL84-R85)

### Test Snapshot Updates:
* Adjusted values in `RewardDistributorTest.json` to align with the updated behavior of the `RewardDistributor` contract. (`snapshots/RewardDistributorTest.json`, [snapshots/RewardDistributorTest.jsonL2-R5](diffhunk://#diff-98c707f538bfb15a3d4fb22d78f76d8ad732a020c27bd05c6fcf4c0fb0203e1fL2-R5))