### PR TITLE
Reverting eoa calls

### DIFF
--- a/docs/autogen/src/src/UVN/L2/L2StakeTable.sol/contract.L2StakeTable.md
+++ b/docs/autogen/src/src/UVN/L2/L2StakeTable.sol/contract.L2StakeTable.md
@@ -1,5 +1,5 @@
 # L2StakeTable
-[Git Source](https://github.com/Uniswap/unichain-contracts/blob/31f7d1e84e305ebb14dd3f50a3450497938c6404/src/UVN/L2/L2StakeTable.sol)
+[Git Source](https://github.com/Uniswap/unichain-contracts/blob/3acb5f12419bea9fea7cca34c0464a9cc73593b7/src/UVN/L2/L2StakeTable.sol)
 
 **Inherits:**
 [IL2StakeTable](/src/interfaces/UVN/L2/IL2StakeTable.sol/interface.IL2StakeTable.md), [Votes](/src/UVN/L1/StakingMiddleware/libraries/Votes.sol/abstract.Votes.md)
@@ -84,6 +84,15 @@ function reportOperatorStake(address operator, uint256 newBalance, address deleg
 |`delegator`|`address`|The address of the delegator.|
 |`newDelegatorStake`|`uint256`|The new stake of the delegator.|
 
+
+### reportDelegatorStake
+
+*Called by the `reportOperatorStake` function externally via try catch to ensure that calls to an EOA do not revert*
+
+
+```solidity
+function reportDelegatorStake(IDelegatorClaim delegatorClaim, address delegator, uint256 newDelegatorStake) external;
+```
 
 ### reportOperatorSlash
 

--- a/docs/autogen/src/src/interfaces/UVN/L2/IL2StakeTable.sol/interface.IL2StakeTable.md
+++ b/docs/autogen/src/src/interfaces/UVN/L2/IL2StakeTable.sol/interface.IL2StakeTable.md
@@ -1,5 +1,5 @@
 # IL2StakeTable
-[Git Source](https://github.com/Uniswap/unichain-contracts/blob/31f7d1e84e305ebb14dd3f50a3450497938c6404/src/interfaces/UVN/L2/IL2StakeTable.sol)
+[Git Source](https://github.com/Uniswap/unichain-contracts/blob/3acb5f12419bea9fea7cca34c0464a9cc73593b7/src/interfaces/UVN/L2/IL2StakeTable.sol)
 
 **Inherits:**
 [IBaseService](/src/interfaces/UVN/IBaseService.sol/interface.IBaseService.md), [IStakeTable](/src/interfaces/UVN/L2/IStakeTable.sol/interface.IStakeTable.md), [IERC7751](/src/interfaces/IERC7751.sol/interface.IERC7751.md)
@@ -39,7 +39,7 @@ Emitted when a delegator stake update fails
 
 
 ```solidity
-event DelegatorStakeUpdateFailed(address indexed operator, address delegator);
+event DelegatorStakeUpdateFailed(address indexed operator, address delegator, bytes reason);
 ```
 
 ## Errors
@@ -57,5 +57,29 @@ Thrown when a delegation is attempted
 
 ```solidity
 error DelegationDisabled();
+```
+
+### OnlyCallableBySelf
+Thrown when the caller is not the L2 stake table contract
+
+
+```solidity
+error OnlyCallableBySelf();
+```
+
+### ZeroAddress
+Thrown when the delegator claim contract is set to a zero address
+
+
+```solidity
+error ZeroAddress();
+```
+
+### NoCode
+Thrown when the delegator claim contract has no code
+
+
+```solidity
+error NoCode();
 ```
 

--- a/snapshots/L2StakeTableTest.json
+++ b/snapshots/L2StakeTableTest.json
@@ -1,8 +1,8 @@
 {
   "onWithdrawal": "41499",
   "reportOperatorSlash": "41967",
-  "reportOperatorStake:delegatorClaim:cold": "86252",
-  "reportOperatorStake:delegatorClaim:warm": "44093",
-  "reportOperatorStake:delegatorClaimWithRewards": "83893",
-  "reportOperatorStake:deployDelegatorClaim": "805267"
+  "reportOperatorStake:delegatorClaim:cold": "87169",
+  "reportOperatorStake:delegatorClaim:warm": "45010",
+  "reportOperatorStake:delegatorClaimWithRewards": "84810",
+  "reportOperatorStake:deployDelegatorClaim": "805290"
 }

--- a/src/UVN/L2/L2StakeTable.sol
+++ b/src/UVN/L2/L2StakeTable.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
+import {IERC7751} from '../../interfaces/IERC7751.sol';
 import {IBaseService, IDelegatorClaim, IL2StakeTable, IStakeTable} from '../../interfaces/UVN/L2/IL2StakeTable.sol';
 import {DefaultDelegatorClaim} from './DefaultDelegatorClaim.sol';
 import {IVotes} from '@openzeppelin/contracts/governance/utils/IVotes.sol';
@@ -49,10 +50,37 @@ contract L2StakeTable is IL2StakeTable, Votes {
         }
         if (delegator != address(0)) {
             IDelegatorClaim delegatorClaim = _delegatorClaims[operator];
-            try delegatorClaim.reportDelegatorStake{gas: MIN_DELEGATOR_UPDATE_GAS}(delegator, newDelegatorStake) {}
-            catch {
-                emit DelegatorStakeUpdateFailed(operator, delegator);
+            try L2StakeTable(address(this)).reportDelegatorStake(delegatorClaim, delegator, newDelegatorStake) {}
+            catch (bytes memory reason) {
+                if (reason.length != 0) {
+                    emit DelegatorStakeUpdateFailed(operator, delegator, reason);
+                } else {
+                    emit DelegatorStakeUpdateFailed(
+                        operator,
+                        delegator,
+                        abi.encodeWithSelector(
+                            IERC7751.WrappedError.selector,
+                            address(delegatorClaim),
+                            IDelegatorClaim.reportDelegatorStake.selector,
+                            NoCode.selector,
+                            ''
+                        )
+                    );
+                }
             }
+        }
+    }
+
+    /// @dev Called by the `reportOperatorStake` function externally via try catch to ensure that calls to an EOA do not revert
+    function reportDelegatorStake(IDelegatorClaim delegatorClaim, address delegator, uint256 newDelegatorStake)
+        external
+    {
+        if (msg.sender != address(this)) revert OnlyCallableBySelf();
+        try delegatorClaim.reportDelegatorStake{gas: MIN_DELEGATOR_UPDATE_GAS}(delegator, newDelegatorStake) {}
+        catch (bytes memory reason) {
+            revert IERC7751.WrappedError(
+                address(delegatorClaim), IDelegatorClaim.reportDelegatorStake.selector, reason, ''
+            );
         }
     }
 
@@ -88,6 +116,7 @@ contract L2StakeTable is IL2StakeTable, Votes {
 
     /// @dev Sets a delegator claim contract for an operator
     function _setDelegatorClaimContract(address operator, IDelegatorClaim delegatorClaim) internal {
+        if (address(delegatorClaim) == address(0)) revert ZeroAddress();
         _delegatorClaims[operator] = delegatorClaim;
         emit DelegatorClaimContractSet(operator, delegatorClaim);
     }

--- a/src/interfaces/UVN/L2/IL2StakeTable.sol
+++ b/src/interfaces/UVN/L2/IL2StakeTable.sol
@@ -12,12 +12,18 @@ interface IL2StakeTable is IBaseService, IStakeTable, IERC7751 {
     /// @notice Emitted when an operator sets a delegator claim contract
     event DelegatorClaimContractSet(address indexed operator, IDelegatorClaim delegatorClaim);
     /// @notice Emitted when a delegator stake update fails
-    event DelegatorStakeUpdateFailed(address indexed operator, address delegator);
+    event DelegatorStakeUpdateFailed(address indexed operator, address delegator, bytes reason);
 
     /// @notice Thrown when the caller is not the L1 stake table sync contract
     error NotStakeTableSync();
     /// @notice Thrown when a delegation is attempted
     error DelegationDisabled();
+    /// @notice Thrown when the caller is not the L2 stake table contract
+    error OnlyCallableBySelf();
+    /// @notice Thrown when the delegator claim contract is set to a zero address
+    error ZeroAddress();
+    /// @notice Thrown when the delegator claim contract has no code
+    error NoCode();
 
     /// @notice Sets a delegator claim contract for an operator
     /// @param delegatorClaim The delegator claim contract to set

--- a/test/UVN/L2/L2StakeTable.t.sol
+++ b/test/UVN/L2/L2StakeTable.t.sol
@@ -237,7 +237,8 @@ contract L2StakeTableTest is Test {
                 ''
             )
         );
-        stakeTable.reportOperatorStake(operator1, 100 ether, delegator1, 100 ether);
+        stakeTable.reportOperatorStake(operator1, 200 ether, delegator1, 100 ether);
+        assertEq(stakeTable.getVotes(operator1), 200 ether);
     }
 
     function test_delegateDisabled() public {
@@ -298,10 +299,36 @@ contract L2StakeTableTest is Test {
                 ''
             )
         );
-        stakeTable.reportOperatorStake(operator1, 100 ether, delegator1, 50 ether);
+        stakeTable.reportOperatorStake(operator1, 200 ether, delegator1, 50 ether);
 
         // Operator stake should still be updated
-        assertEq(stakeTable.getVotes(operator1), 100 ether);
+        assertEq(stakeTable.getVotes(operator1), 200 ether);
+    }
+
+    function test_delegatorStakeUpdateReturnBomb() public {
+        stakeTable.reportOperatorStake(operator1, 100 ether, address(0), 0);
+
+        // Assign a failing claim contract
+        ReturnBombDelegatorClaim failingClaim = new ReturnBombDelegatorClaim();
+        vm.prank(operator1);
+        stakeTable.overrideDelegatorClaimContract(failingClaim);
+
+        // Try to update delegator stake (should not revert)
+        vm.expectEmit(true, true, true, true);
+        emit IL2StakeTable.DelegatorStakeUpdateFailed(
+            operator1,
+            delegator1,
+            abi.encodeWithSelector(
+                IERC7751.WrappedError.selector,
+                address(failingClaim),
+                IDelegatorClaim.reportDelegatorStake.selector,
+                '',
+                ''
+            )
+        );
+        stakeTable.reportOperatorStake(operator1, 200 ether, delegator1, 50 ether);
+        // Operator stake should still be updated
+        assertEq(stakeTable.getVotes(operator1), 200 ether);
     }
 
     function test_integration_rewardDistribution() public {
@@ -453,5 +480,13 @@ contract MockDelegatorClaim is IDelegatorClaim {
 contract FailingDelegatorClaim is IDelegatorClaim {
     function reportDelegatorStake(address, uint256) external pure override {
         revert('oh no something went wrong :(');
+    }
+}
+
+contract ReturnBombDelegatorClaim is IDelegatorClaim {
+    function reportDelegatorStake(address, uint256) external pure override {
+        assembly {
+            revert(0, 1000000)
+        }
     }
 }

--- a/test/UVN/L2/L2StakeTable.t.sol
+++ b/test/UVN/L2/L2StakeTable.t.sol
@@ -5,6 +5,8 @@ import {DefaultDelegatorClaim} from '../../../src/UVN/L2/DefaultDelegatorClaim.s
 import {L2StakeTable} from '../../../src/UVN/L2/L2StakeTable.sol';
 
 import {ExampleOperatorFeeManager} from '../../../src/UVN/L2/examples/ExampleOperatorFeeManager.sol';
+
+import {IERC7751} from '../../../src/interfaces/IERC7751.sol';
 import {IDelegatorClaim} from '../../../src/interfaces/UVN/L2/IDelegatorClaim.sol';
 import {IL2StakeTable} from '../../../src/interfaces/UVN/L2/IL2StakeTable.sol';
 import {Test} from 'forge-std/Test.sol';
@@ -186,6 +188,13 @@ contract L2StakeTableTest is Test {
         stakeTable.onWithdrawal(operator1);
     }
 
+    function test_RevertIf_overrideWithZeroAddress() public {
+        stakeTable.reportOperatorStake(operator1, 100 ether, address(0), 0);
+        vm.prank(operator1);
+        vm.expectRevert(IL2StakeTable.ZeroAddress.selector);
+        stakeTable.overrideDelegatorClaimContract(IDelegatorClaim(address(0)));
+    }
+
     function test_overrideDelegatorClaimContract() public {
         stakeTable.reportOperatorStake(operator1, 100 ether, address(0), 0);
         address defaultClaim = stakeTable.beneficiary(operator1);
@@ -208,6 +217,27 @@ contract L2StakeTableTest is Test {
 
         assertEq(stakeTable.beneficiary(operator2), address(customClaim));
         assertNotEq(stakeTable.beneficiary(operator1), address(customClaim));
+    }
+
+    function test_shouldNotRevertIfOverrideIsEOA() public {
+        stakeTable.reportOperatorStake(operator1, 100 ether, address(0), 0);
+        vm.prank(operator1);
+        address eoa = makeAddr('EOA');
+        stakeTable.overrideDelegatorClaimContract(IDelegatorClaim(eoa));
+        assertEq(stakeTable.beneficiary(operator1), eoa);
+        vm.expectEmit(true, true, false, true);
+        emit IL2StakeTable.DelegatorStakeUpdateFailed(
+            operator1,
+            delegator1,
+            abi.encodeWithSelector(
+                IERC7751.WrappedError.selector,
+                eoa,
+                IDelegatorClaim.reportDelegatorStake.selector,
+                IL2StakeTable.NoCode.selector,
+                ''
+            )
+        );
+        stakeTable.reportOperatorStake(operator1, 100 ether, delegator1, 100 ether);
     }
 
     function test_delegateDisabled() public {
@@ -256,8 +286,18 @@ contract L2StakeTableTest is Test {
         stakeTable.overrideDelegatorClaimContract(failingClaim);
 
         // Try to update delegator stake (should not revert)
-        vm.expectEmit(true, true, false, false);
-        emit IL2StakeTable.DelegatorStakeUpdateFailed(operator1, delegator1);
+        vm.expectEmit(true, true, true, true);
+        emit IL2StakeTable.DelegatorStakeUpdateFailed(
+            operator1,
+            delegator1,
+            abi.encodeWithSelector(
+                IERC7751.WrappedError.selector,
+                address(failingClaim),
+                IDelegatorClaim.reportDelegatorStake.selector,
+                abi.encodeWithSignature('Error(string)', 'oh no something went wrong :('),
+                ''
+            )
+        );
         stakeTable.reportOperatorStake(operator1, 100 ether, delegator1, 50 ether);
 
         // Operator stake should still be updated
@@ -412,6 +452,6 @@ contract MockDelegatorClaim is IDelegatorClaim {
 
 contract FailingDelegatorClaim is IDelegatorClaim {
     function reportDelegatorStake(address, uint256) external pure override {
-        revert('oh noeeee something went wrong :(');
+        revert('oh no something went wrong :(');
     }
 }


### PR DESCRIPTION
This pull request introduces several updates to the `L2StakeTable` contract and its associated interfaces, tests, and documentation. The changes focus on improving error handling, adding new functionality, and enhancing test coverage. Key updates include the addition of a new `reportDelegatorStake` function, improved error reporting with detailed reasons, and new test cases for edge scenarios.

### Functional Enhancements:
* Added a new `reportDelegatorStake` function to the `L2StakeTable` contract, which is called externally via `try-catch` to prevent reverts when interacting with externally owned accounts (EOAs).
* Introduced stricter validation when setting a delegator claim contract, reverting with a `ZeroAddress` error if the address is invalid.

### Error Handling Improvements:
* Enhanced the `DelegatorStakeUpdateFailed` event to include a `bytes reason` parameter, providing detailed information about why the update failed. [[1]](diffhunk://#diff-470ebc18aa9b6d46529195ac7d22267d641939b0faedd55694195c9f8b0cb1f3L15-R26) [[2]](diffhunk://#diff-804fc3cd441de84c88ac4bbd3b1495c902ea57d532c2eaf7b23a1c9b18f2da7bL52-R83)
* Added new custom errors (`OnlyCallableBySelf`, `ZeroAddress`, and `NoCode`) to the `IL2StakeTable` interface for better error granularity.

### Test Suite Enhancements:
* Added new test cases to cover edge scenarios, such as attempts to override a delegator claim contract with a zero address or an EOA. [[1]](diffhunk://#diff-7e7f1f9fc16fbbae112f37e31530b5046e90a0aeee4724794524fead45866d90R191-R197) [[2]](diffhunk://#diff-7e7f1f9fc16fbbae112f37e31530b5046e90a0aeee4724794524fead45866d90R222-R243)
* Introduced tests for handling reverts with detailed error messages and "return bomb" scenarios to ensure robustness. [[1]](diffhunk://#diff-7e7f1f9fc16fbbae112f37e31530b5046e90a0aeee4724794524fead45866d90L259-R331) [[2]](diffhunk://#diff-7e7f1f9fc16fbbae112f37e31530b5046e90a0aeee4724794524fead45866d90L415-R490)

### Documentation and Code Updates:
* Updated the documentation for `L2StakeTable` and `IL2StakeTable` to reflect the new function and event changes. [[1]](diffhunk://#diff-8809067b68b1293ac2c23d647f2da602f79bb3bede7760a82ae4290d4fec2030R88-R96) [[2]](diffhunk://#diff-2bdb46c291b6d9795a85be5bfd25765234a7abc026a85beeec7f28940536681bL42-R42)
* Updated the snapshot file `L2StakeTableTest.json` to reflect gas cost changes due to the new functionality.